### PR TITLE
Fix Bug in Dataset Building Process

### DIFF
--- a/mmgpt/datasets/builder.py
+++ b/mmgpt/datasets/builder.py
@@ -23,7 +23,7 @@ def build_dataset(dataset_config, **kwargs):
         return ConcatDataset(datasets)
     dataset_type = dataset_config.pop("type")
     sample = dataset_config.pop("sample", -1)
-    if dataset_config.type == "llava":
+    if dataset_type == "llava":
         dataset = LlavaDataset(
             **dataset_config,
             **kwargs,

--- a/mmgpt/train/instruction_finetune.py
+++ b/mmgpt/train/instruction_finetune.py
@@ -172,7 +172,7 @@ def main():
         raise ValueError("dataset_config must be specified")
 
     dataset = build_dataset(
-        config=dataset_config.visual_datasets,
+        dataset_config=dataset_config.visual_datasets,
         vis_processor=image_processor,
         tokenizer=tokenizer,
     )
@@ -187,7 +187,7 @@ def main():
     # build language dataset and dataloader for multi-modality training
     if dataset_config.language_datasets is not None and len(args.language_datasets) > 0:
         lang_dataset = build_dataset(
-            config=dataset_config.language_datasets,
+            dataset_config=dataset_config.language_datasets,
             tokenizer=tokenizer,
         )
         lang_dataloader = DataLoader(

--- a/mmgpt/train/instruction_finetune.py
+++ b/mmgpt/train/instruction_finetune.py
@@ -185,7 +185,7 @@ def main():
     )
 
     # build language dataset and dataloader for multi-modality training
-    if dataset_config.language_datasets is not None and len(args.language_datasets) > 0:
+    if dataset_config.get('language_datasets') is not None and len(args.language_datasets) > 0:
         lang_dataset = build_dataset(
             dataset_config=dataset_config.language_datasets,
             tokenizer=tokenizer,


### PR DESCRIPTION
This commit addresses a bug in the dataset building process in our multimodal GPT (mmGPT) framework. Specifically, the bug was related to the way we were handling dataset configuration in both the builder.py and instruction_finetune.py scripts.

The changes include:

In builder.py, we changed the way the type of dataset is identified in the build_dataset function. Previously, the function checked for the type of dataset using dataset_config.type. However, dataset_config.type was already popped from the dictionary and therefore did not exist. The bug fix changes this to dataset_type, which correctly refers to the popped value.
In instruction_finetune.py, the build_dataset function was being called with incorrect keyword argument config. This was updated to the correct keyword argument dataset_config, ensuring the function receives the dataset configuration as intended.
These changes are expected to fix the dataset building bug and allow for successful dataset building and training in the mmGPT framework.