### PR TITLE
[Add] Introduce Pre-Commit Hooks and Configuration Files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+repos:
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+  - repo: https://github.com/zhouzaida/isort
+    rev: 5.12.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.32.0
+    hooks:
+      - id: yapf
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+      - id: double-quote-string-fixer
+      - id: check-merge-conflict
+      - id: fix-encoding-pragma
+        args: ["--remove"]
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.9
+    hooks:
+      - id: mdformat
+        args: ["--number"]
+        additional_dependencies:
+          - mdformat-openmmlab
+          - mdformat_frontmatter
+          - linkify-it-py
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.1
+    hooks:
+      - id: codespell
+  - repo: https://github.com/myint/docformatter
+    rev: v1.3.1
+    hooks:
+      - id: docformatter
+        args: ["--in-place", "--wrap-descriptions", "79"]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.0.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py36-plus"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[yapf]
+based_on_style = pep8
+blank_line_before_nested_class_or_def = true
+split_before_expression_after_opening_paren = true
+
+[isort]
+line_length = 79
+multi_line_output = 0
+extra_standard_library = setuptools
+known_first_party = mmgpt
+known_third_party = PIL,cv2,mmcv,numpy,pytest,mmengine,torch
+no_lines_before = STDLIB,LOCALFOLDER
+default_section = THIRDPARTY

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,4 @@ known_first_party = mmgpt
 known_third_party = PIL,cv2,mmcv,numpy,pytest,mmengine,torch
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY
+


### PR DESCRIPTION
# Description

This commit introduces a pre-commit configuration file and a setup configuration file to improve the code quality and maintainability of the project. 

Changes:
1. A new `.pre-commit-config.yaml` file has been added, which includes several hooks to maintain code quality and consistency. These hooks include:
    - `flake8` for Python style guide enforcement
    - `isort` for sorting imports
    - `yapf` for auto-formatting Python code
    - `trailing-whitespace`, `check-yaml`, `end-of-file-fixer`, `requirements-txt-fixer`, `double-quote-string-fixer`, `check-merge-conflict`, `fix-encoding-pragma`, `mixed-line-ending` for various code cleanup and sanity checks
    - `mdformat` for Markdown formatting
    - `codespell` for spell checking
    - `docformatter` for Python docstring formatting
    - `pyupgrade` for upgrading Python syntax
2. A new `setup.cfg` file has been added, which includes configuration settings for `yapf` and `isort`.

These changes should help in maintaining the quality of the codebase, enforcing coding standards, and making the review process smoother and more efficient.
